### PR TITLE
Chores mongo+key

### DIFF
--- a/lib/api/apiGatewayConstruct.ts
+++ b/lib/api/apiGatewayConstruct.ts
@@ -1,6 +1,8 @@
 import { Construct } from "constructs";
 import * as api from "aws-cdk-lib/aws-apigateway";
 import { Function } from "aws-cdk-lib/aws-lambda";
+import { GetApiKeyCr } from "./getApiKeyCr";
+import { CfnOutput } from "aws-cdk-lib";
 
 interface APIConstructProps {
   readonly eventsLambda: Function;
@@ -22,6 +24,9 @@ export default class ApiConstruct extends Construct {
     });
 
     const apiKey = new api.ApiKey(this, "reverb-api-key");
+
+    const apiKeyCr = new GetApiKeyCr(this, "reverb-api-key-cr", { apiKey });
+    new CfnOutput(this, "apiKey", { value: apiKeyCr.apikeyValue });
 
     const apiUsagePlan = new api.UsagePlan(this, "usage-plan", {
       name: "reverb-api-usage-plan",

--- a/lib/api/apiGatewayConstruct.ts
+++ b/lib/api/apiGatewayConstruct.ts
@@ -18,39 +18,33 @@ export default class ApiConstruct extends Construct {
         allowOrigins: api.Cors.ALL_ORIGINS,
         allowMethods: ["GET", "POST"],
       },
+      apiKeySourceType: api.ApiKeySourceType.HEADER,
     });
 
-    const apiDeployment = new api.Deployment(this, "ApiDeployment", {
-      api: this.apigw,
-    });
-
-    const apiStage = new api.Stage(this, "ApiStage", {
-      deployment: apiDeployment,
-      stageName: "reverb-prod-stage",
-    });
-
-    const apiKey = new api.ApiKey(this, "reverb-api-key", {
-      enabled: true,
-    });
+    const apiKey = new api.ApiKey(this, "reverb-api-key");
 
     const apiUsagePlan = new api.UsagePlan(this, "usage-plan", {
       name: "reverb-api-usage-plan",
+      apiStages: [
+        {
+          api: this.apigw,
+          stage: this.apigw.deploymentStage,
+        },
+      ],
       throttle: {
         burstLimit: 1000,
         rateLimit: 100,
       },
     });
     apiUsagePlan.addApiKey(apiKey);
-    apiUsagePlan.addApiStage({
-      api: this.apigw,
-      stage: apiStage,
-    });
 
     // Set lambda routes
     const eventsResource = this.apigw.root.addResource("events");
     const webhooksResource = this.apigw.root.addResource("webhooks");
     const lambdaIntegration = new api.LambdaIntegration(props.eventsLambda);
-    eventsResource.addMethod("POST", lambdaIntegration);
+    eventsResource.addMethod("POST", lambdaIntegration, {
+      apiKeyRequired: true,
+    });
     webhooksResource.addMethod("POST", lambdaIntegration);
   }
 }

--- a/lib/api/getApiKeyCr.ts
+++ b/lib/api/getApiKeyCr.ts
@@ -1,0 +1,48 @@
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+import { RetentionDays } from "aws-cdk-lib/aws-logs";
+import {
+  AwsCustomResource,
+  AwsCustomResourcePolicy,
+  AwsSdkCall,
+  PhysicalResourceId,
+} from "aws-cdk-lib/custom-resources";
+import { IApiKey } from "aws-cdk-lib/aws-apigateway";
+
+export interface GetApiKeyCrProps {
+  apiKey: IApiKey;
+}
+
+export class GetApiKeyCr extends Construct {
+  apikeyValue: string;
+
+  constructor(scope: Construct, id: string, props: GetApiKeyCrProps) {
+    super(scope, id);
+
+    const apiKey: AwsSdkCall = {
+      service: "APIGateway",
+      action: "getApiKey",
+      parameters: {
+        apiKey: props.apiKey.keyId,
+        includeValue: true,
+      },
+      physicalResourceId: PhysicalResourceId.of(`APIKey:${props.apiKey.keyId}`),
+    };
+
+    const apiKeyCr = new AwsCustomResource(this, "api-key-cr", {
+      policy: AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [props.apiKey.keyArn],
+          actions: ["apigateway:GET"],
+        }),
+      ]),
+      logRetention: RetentionDays.ONE_DAY,
+      onCreate: apiKey,
+      onUpdate: apiKey,
+    });
+
+    apiKeyCr.node.addDependency(props.apiKey);
+    this.apikeyValue = apiKeyCr.getResponseField("value");
+  }
+}

--- a/lib/ecs-containers/ecsContainer.ts
+++ b/lib/ecs-containers/ecsContainer.ts
@@ -56,5 +56,7 @@ export class EcsConstruct extends Construct {
       rdsSecret,
       mongoConstruct,
     });
+
+    workersContainer.node.addDependency(functionContainer);
   }
 }

--- a/lib/mongo/setup.sh
+++ b/lib/mongo/setup.sh
@@ -43,4 +43,8 @@ roles: [
 ]
 })
 
+db.logs.createIndex({ "message": 1, "timestamp": 1 })
+db.logs.createIndex({ "meta.funcId": 1 , "timestamp": 1 })
+db.logs.createIndex({ "meta.eventId": 1 })
+
 EOF

--- a/lib/rds/rdsConstruct.ts
+++ b/lib/rds/rdsConstruct.ts
@@ -70,7 +70,7 @@ export class RdsConstruct extends Construct {
       maxAllocatedStorage: 128,
       allowMajorVersionUpgrade: false,
       autoMinorVersionUpgrade: true,
-      backupRetention: cdk.Duration.days(0),
+      backupRetention: cdk.Duration.days(1),
       deleteAutomatedBackups: true,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       deletionProtection: false,


### PR DESCRIPTION
Changes:

1. API Key attached to POST /events.
2. Added Indexes to mongo startup script to speed up log retrieval.
3. Changed RDS backup retention from 0 day(no backup) to 1 day.
4. Workers requires functions service to be up before it deploys. This prevents service connect issues.
5. API KEY is output at the end of a deploy.